### PR TITLE
fix: [MMC-542] IllegalMonitorStateException on Bloom Filter lock release in multi-pod environment

### DIFF
--- a/src/main/java/it/gov/pagopa/onboarding/citizen/service/BloomFilterInitializer.java
+++ b/src/main/java/it/gov/pagopa/onboarding/citizen/service/BloomFilterInitializer.java
@@ -99,9 +99,13 @@ public class BloomFilterInitializer {
      */
     @PostConstruct
     public void initialize() {
-        acquireLock()
-            .flatMap(this::processInitialization)
-            .block(Duration.ofSeconds(120));
+        try {
+            acquireLock()
+                .flatMap(this::processInitialization)
+                .block(Duration.ofSeconds(120));
+        } catch (Exception e) {
+            log.error("[BLOOM-FILTER-INITIALIZER] Initialization failed or timed out: {}", e.getMessage(), e);
+        }
     }
 
     /**
@@ -285,17 +289,20 @@ public class BloomFilterInitializer {
     /**
      * <p>Releases the distributed lock acquired for Bloom Filter operations.</p>
      *
-     * <p><b>Note:</b> {@code RLockReactive.unlock()} returns a {@code Mono<Void>} — calling it
-     * without subscribing is a no-op and leaves the lock held until its TTL expiry (60s).
-     * {@code .subscribe()} here is safe and intentional: the unlock is a fire-and-complete
-     * side-effect that does not need to be awaited by the caller chain.</p>
+     * <p><b>Note:</b> Uses blocking call to ensure the lock is released on the same thread
+     * that acquired it. This prevents IllegalMonitorStateException when the reactive chain
+     * completes on a different thread (e.g., Netty thread).</p>
      */
     private void releaseLock() {
-        redissonClient.getLock(REDIS_LOCK_NAME)
-                .unlock()
-                .doOnSuccess(v -> log.info("[BLOOM-FILTER-INITIALIZER] Lock released."))
-                .doOnError(e -> log.error("[BLOOM-FILTER-INITIALIZER] Failed to release lock: {}", e.getMessage(), e))
-                .subscribe();
+        try {
+            redissonClient.getLock(REDIS_LOCK_NAME)
+                    .unlock()
+                    .doOnSuccess(v -> log.info("[BLOOM-FILTER-INITIALIZER] Lock released."))
+                    .doOnError(e -> log.error("[BLOOM-FILTER-INITIALIZER] Failed to release lock: {}", e.getMessage(), e))
+                    .block(Duration.ofSeconds(5));
+        } catch (Exception e) {
+            log.error("[BLOOM-FILTER-INITIALIZER] Error releasing lock: {}", e.getMessage(), e);
+        }
     }
 
 }


### PR DESCRIPTION
- Replace fire-and-forget subscribe() with blocking block(Duration) in releaseLock() to ensure unlock is called from the same thread that acquired the lock
- Add try/catch to initialize() to prevent pod crash if Redis is unavailable or lock timeout occurs at startup
- Bug became evident after scaling to multi-pod deployment where the distributed lock is actively contested between instances

<!--- 
Thanks for your contribution!

Please make sure to provide a clear description. The more context you provide,
the faster we can review and merge your change.
-->

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it closes an issue, link it here: e.g. Closes #123 -->


---

### ❗ IMPORTANT: Automatic Release Check
*These checks guide the TBD process.*

**1. Type of Change (for the Merge Commit Title)**
Which Conventional Commit prefix best describes this change?
**This prefix MUST be used in the "Squash and Merge" commit title.**

- [ ] `feat:` (A new feature for the user)
- [ ] `fix:` (A bug fix for the user)
- [ ] `docs:` (Documentation update)
- [ ] `chore:` (Maintenance, CI, configuration, dependencies)
- [ ] `refactor:` (Code refactoring without functional changes)
- [ ] `test:` (Adding or modifying tests)
- [ ] `style:` (Code formatting)

*(Remember: only `feat:` and `fix:` will trigger a new release)*

**2. Feature Flag Check (for Trunk Based Development)**
If you are adding a `feat:`, how is it managed?

- [ ] This is not a feature (it's a `fix:`, `chore:`, etc.)
- [ ] It's a complete feature and ready to be released to users.
- [ ] It's an incomplete or in-test feature, and it is **hidden behind a Feature Flag**.

**3. Breaking Change**
Does this modification introduce a *Breaking Change*?

- [ ] No
- [ ] **Yes**
<!--- 
      If YES: 
      1. The merge commit title MUST contain `feat!: ...` or `fix!: ...`
      2. You MUST add a description of the breaking change in the commit footer,
         starting with `BREAKING CHANGE: [description]`
-->

---

### Other information
<!-- Screenshots, GIFs, or any other useful context. -->